### PR TITLE
Replace md5sum with sha256 to avoid collisions.

### DIFF
--- a/one.sh
+++ b/one.sh
@@ -5,17 +5,16 @@
 # script does nothing if it was previously used to launch the same command
 # and that instance is still running.
 #
-# /tmp/one-<md5sum of the arguments>.pid is used as the lock file. This file
+# /tmp/one-<sha256sum of the arguments>.pid is used as the lock file. This file
 # is removed if the process it refers to isn't actually running.
 #
 # Usage:   ./one.sh <command> <arguments>
 # Example: ./one.sh wget --mirror http://mysite.com
 #
 # See http://patrickmylund.com/projects/one/ for more information.
-
-# Switch out LFILE for something static to avoid running md5sum and cut, e.g.
+# Switch out LFILE for something static to avoid running sha256sum and cut, e.g.
 # LFILE=/tmp/one.pid
-LFILE=/tmp/one-`echo "$@" | md5sum | cut -d\  -f1`.pid
+LFILE=/tmp/one-`echo "$@" | sha256sum | cut -d\  -f1`.pid
 if [ -e ${LFILE} ] && kill -0 `cat ${LFILE}`; then
    exit
 fi


### PR DESCRIPTION
I can't reproduce the exact commands as I didn't log the lots and lots of automated commands with different args that I ran with this, but some commands might have failed due to a collision.